### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,6 +1,8 @@
 # Based on https://github.com/mvdan/github-actions-golang
 on: [push, pull_request]
 name: Tests
+permissions:
+  contents: read
 jobs:
   test:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/qba73/arc/security/code-scanning/1](https://github.com/qba73/arc/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify `contents: read`, which is sufficient for the workflow to check out the repository and run tests. This change ensures that the workflow does not inadvertently gain unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
